### PR TITLE
BufferedToken & USM - Split checks and transfers from business logic

### DIFF
--- a/contracts/BufferedToken.sol
+++ b/contracts/BufferedToken.sol
@@ -26,6 +26,26 @@ contract BufferedToken is ERC20 {
     }
 
     /**
+     * @notice Mint USM from Eth. Inheriting contract must handle the Ether transfers.
+     */
+    function _mint(uint ethAmount) internal returns (uint) {
+        uint usmAmount = _ethToUsm(ethAmount);
+        ethPool = ethPool.add(ethAmount);
+        super._mint(msg.sender, usmAmount);
+        return usmAmount;
+    }
+
+    /**
+     * @notice Burn USM for Eth. Inheriting contract must handle the Ether transfers.
+     */
+    function _burn(uint usmAmount) internal returns (uint) {
+        uint ethAmount = _usmToEth(usmAmount);
+        ethPool = ethPool.sub(ethAmount);
+        super._burn(msg.sender, usmAmount);
+        return ethAmount;
+    }
+
+    /**
      * @notice Calculate the amount of ETH in the buffer
      *
      * @return ETH buffer

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -33,30 +33,26 @@ contract USM is BufferedToken {
     }
 
     /**
-     * @notice Mint ETH for USM. Uses msg.value as the ETH deposit.
+     * @notice Mint ETH for USM with checks and asset transfers. Uses msg.value as the ETH deposit.
      */
     function mint() external payable {
         require(msg.value > MIN_ETH_AMOUNT, "Must deposit more than 0.001 ETH");
-        uint usmAmount = _ethToUsm(msg.value);
-        ethPool = ethPool.add(msg.value);
-        _mint(msg.sender, usmAmount);
+        _mint(msg.value);
         // set latest fum price
         _setLatestFumPrice(fumPrice());
     }
 
     /**
-     * @notice Burn USM for ETH.
+     * @notice Burn USM for ETH with checks and asset transfers.
      *
-     * @param _usmAmount Amount of USM to burn.
+     * @param _usmToBurn Amount of USM to burn.
      */
-    function burn(uint _usmAmount) external {
-        require(_usmAmount >= WAD, "Must burn at least 1 USM");
-        uint ethAmount = _usmToEth(_usmAmount);
-        ethPool = ethPool.sub(ethAmount);
-        require(totalSupply().sub(_usmAmount).wadDiv(_ethToUsm(ethPool)) <= MAX_DEBT_RATIO,
+    function burn(uint _usmToBurn) external {
+        require(_usmToBurn >= WAD, "Must burn at least 1 USM");
+        uint ethToSend = _burn(_usmToBurn);
+        require(debtRatio() <= MAX_DEBT_RATIO,
             "Cannot burn this amount. Will take debt ratio above maximum.");
-        _burn(msg.sender, _usmAmount);
-        Address.sendValue(msg.sender, ethAmount);
+        Address.sendValue(msg.sender, ethToSend);
         // set latest fum price
         _setLatestFumPrice(fumPrice());
     }

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.6.7;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/math/Math.sol";
 import "./BufferedToken.sol";
 import "./WadMath.sol";
 import "./FUM.sol";
@@ -14,10 +15,11 @@ import "@nomiclabs/buidler/console.sol";
  */
 contract USM is BufferedToken {
     using SafeMath for uint;
+    using Math for uint;
     using WadMath for uint;
 
-    uint constant MIN_ETH_AMOUNT = WAD / 1000;         // 0.001 (of an ETH)
-    uint constant MAX_DEBT_RATIO = 900000000000000000; // 90%
+    uint constant public MIN_ETH_AMOUNT = WAD / 1000;         // 0.001 (of an ETH)
+    uint constant public MAX_DEBT_RATIO = 900000000000000000; // 90%
 
     FUM public fum;
     uint public latestFumPrice;
@@ -30,6 +32,21 @@ contract USM is BufferedToken {
     constructor(address _oracle) public BufferedToken(_oracle, "Minimal USD", "USM") {
         _setLatestFumPrice(MIN_ETH_AMOUNT);
         fum = new FUM();
+    }
+
+    /**
+     * @notice Calculates the price of FUM using its total supply
+     * and ETH buffer
+     */
+    function fumPrice() public view returns (uint) {
+        int buffer = ethBuffer();
+        // if we're underwater, use the last fum price
+        if (buffer <= 0 || debtRatio() > MAX_DEBT_RATIO) {
+            return latestFumPrice;
+        }
+
+        uint fumTotalSupply = fum.totalSupply().max(WAD); // fumTotalSupply is floored at WAD
+        return uint(buffer).wadDiv(fumTotalSupply);
     }
 
     /**
@@ -109,24 +126,5 @@ contract USM is BufferedToken {
         uint previous = latestFumPrice;
         latestFumPrice = _fumPrice;
         emit LatestFumPriceChanged(previous, latestFumPrice);
-    }
-
-    /**
-     * @notice Calculates the price of FUM using its total supply
-     * and ETH buffer
-     */
-    function fumPrice() public view returns (uint) {
-        int buffer = ethBuffer();
-        // if we're underwater, use the last fum price
-        if (buffer <= 0 || debtRatio() > MAX_DEBT_RATIO) {
-            return latestFumPrice;
-        }
-
-        uint fumTotalSupply = fum.totalSupply();
-        // If there are no FUM, assume there's 1
-        if (fumTotalSupply == 0) {
-            fumTotalSupply = WAD;
-        }
-        return uint(buffer).wadDiv(fumTotalSupply);
     }
 }

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -18,7 +18,8 @@ contract USM is BufferedToken {
     using Math for uint;
     using WadMath for uint;
 
-    uint constant public MIN_ETH_AMOUNT = WAD / 1000;         // 0.001 (of an ETH)
+    uint constant public MIN_ETH_AMOUNT = WAD / 1000;         // 0.001 ETH
+    uint constant public MIN_BURN_AMOUNT = WAD;               // 1 USM
     uint constant public MAX_DEBT_RATIO = 900000000000000000; // 90%
 
     FUM public fum;
@@ -65,7 +66,7 @@ contract USM is BufferedToken {
      * @param _usmToBurn Amount of USM to burn.
      */
     function burn(uint _usmToBurn) external {
-        require(_usmToBurn >= WAD, "Must burn at least 1 USM");
+        require(_usmToBurn >= MIN_BURN_AMOUNT, "Must burn at least 1 USM");
         uint ethToSend = _burn(_usmToBurn);
         require(debtRatio() <= MAX_DEBT_RATIO,
             "Cannot burn this amount. Will take debt ratio above maximum.");

--- a/contracts/mocks/MockBufferedToken.sol
+++ b/contracts/mocks/MockBufferedToken.sol
@@ -14,17 +14,12 @@ contract MockBufferedToken is BufferedToken {
 
     constructor(address _oracle, string memory _name, string memory _symbol) public BufferedToken(_oracle, _name, _symbol) {}
 
-    function mint() external payable {
-        uint usmAmount = _ethToUsm(msg.value);
-        ethPool = ethPool.add(msg.value);
-        _mint(msg.sender, usmAmount);
+    function mint(uint ethAmount) public returns (uint) {
+        return _mint(ethAmount);
     }
 
-    function burn(uint usmAmount) public {
-        uint ethAmount = _usmToEth(usmAmount);
-        ethPool = ethPool.sub(ethAmount);
-        _burn(msg.sender, usmAmount);
-        Address.sendValue(msg.sender, ethAmount);
+    function burn(uint usmAmount) public returns (uint) {
+        return _burn(usmAmount);
     }
 
     function ethToUsm(uint _ethAmount) public view returns (uint) {

--- a/test/02_BufferedToken.test.js
+++ b/test/02_BufferedToken.test.js
@@ -1,7 +1,7 @@
 const { BN, expectRevert } = require('@openzeppelin/test-helpers');
 
 const TestOracle = artifacts.require("./TestOracle.sol");
-const BufferedToken = artifacts.require("./MockBufferedToken.sol");
+const MockBufferedToken = artifacts.require("./MockBufferedToken.sol");
 
 const EVM_REVERT = "VM Exception while processing transaction: revert";
 
@@ -20,7 +20,7 @@ contract("BufferedToken", accounts => {
     
     beforeEach(async() => {
         oracle = await TestOracle.new(price, shift, { from: deployer });
-        token = await BufferedToken.new(oracle.address, "Name", "Symbol", { from: deployer });
+        token = await MockBufferedToken.new(oracle.address, "Name", "Symbol", { from: deployer });
     });
 
     describe("deployment", async () => {
@@ -62,14 +62,14 @@ contract("BufferedToken", accounts => {
         })
 
         it("updates the debt ratio on mint", async () => {
-            await token.mint({ from: user, value: WAD });
+            await token.mint(WAD, { from: user });
             let debtRatio = (await token.debtRatio()).toString();
             debtRatio.should.equal(WAD.toString());
         })
 
         describe("with a positive supply", async () => {
             beforeEach(async() => {
-                await token.mint({ from: user, value: WAD });
+                await token.mint(WAD, { from: user });
             });
 
             it("price changes affect the debt ratio", async () => {

--- a/test/02_BufferedToken.test.js
+++ b/test/02_BufferedToken.test.js
@@ -80,6 +80,17 @@ contract("BufferedToken", accounts => {
                 await token.mint(WAD, { from: user });
             });
 
+            it("allows burning", async () => {
+                const tokenBalance = (await token.balanceOf(user));
+
+                const returnedEth = (await token.burn.call(tokenBalance, { from: user })).toString(); // .call transforms a transaction into a `view` function
+                returnedEth.should.equal(tokenBalance.mul(WAD).div(priceWAD).toString());
+
+                await token.burn(tokenBalance, { from: user });
+                const newTokenBalance = (await token.balanceOf(user)).toString();
+                newTokenBalance.should.equal('0');
+            })
+
             it("price changes affect the debt ratio", async () => {
                 const debtRatio = await token.debtRatio();
                 const factor = new BN('2');

--- a/test/02_BufferedToken.test.js
+++ b/test/02_BufferedToken.test.js
@@ -61,6 +61,14 @@ contract("BufferedToken", accounts => {
             debtRatio.should.equal(ZERO.toString());
         })
 
+        it("allows minting", async () => {
+            const oneEth = WAD;
+
+            await token.mint(oneEth, { from: user });
+            const tokenBalance = (await token.balanceOf(user)).toString();
+            tokenBalance.should.equal(oneEth.mul(priceWAD).div(WAD).toString());
+        })
+
         it("updates the debt ratio on mint", async () => {
             await token.mint(WAD, { from: user });
             let debtRatio = (await token.debtRatio()).toString();

--- a/test/03_USM.test.js
+++ b/test/03_USM.test.js
@@ -75,6 +75,25 @@ contract("USM", accounts => {
                     "Must deposit more than 0.001 ETH"
                 );
             })
+
+            describe("with existing USM supply", () => {
+                beforeEach(async () => {
+                    const oneEth = WAD;
+                    await usm.mint({ from: user, value: oneEth });
+                });
+
+                it("allows burning USM", async () => {
+                    const usmBalance = (await usm.balanceOf(user)).toString();
+                    const fumPrice = (await usm.latestFumPrice()).toString();
+    
+                    await usm.burn(usmBalance, { from: user });
+                    const newUsmBalance = (await usm.balanceOf(user)).toString();
+                    newUsmBalance.should.equal('0');
+    
+                    const newFumPrice = (await usm.latestFumPrice()).toString();
+                    newFumPrice.should.equal(fumPrice); // Burning doesn't change the fum price if buffer is 0
+                })
+            });
         });
         /*
         it("sets the correct debt ratio", async () => {


### PR DESCRIPTION
I moved some code from `mint` and `burn` in `USM.sol` to `BufferedToken.sol` so that `BufferedToken` is the one managing the `ethPool` variable.

Also rewrote all the tests related to minting and burning.