### PR TITLE
Feat/limit orders - Fixes #24

### DIFF
--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -6,7 +6,7 @@ import "./IUSM.sol";
 import "./external/IWETH9.sol";
 
 
-contract EthProxy {
+contract Proxy {
     using Address for address payable;
     IUSM public usm;
     IWETH9 public weth;
@@ -20,10 +20,10 @@ contract EthProxy {
         weth.approve(address(usm), uint(-1));
     }
 
-    /// @dev The WETH9 contract will send ether to EthProxy on `weth.withdraw` using this function.
+    /// @dev The WETH9 contract will send ether to Proxy on `weth.withdraw` using this function.
     receive() external payable { }
 
-    /// @dev Users use `mint` in EthProxy to post ETH to USM (amount = msg.value), which will be converted to Weth here.
+    /// @dev Users use `mint` in Proxy to post ETH to USM (amount = msg.value), which will be converted to Weth here.
     /// @param to Receiver of the minted USM
     function mint(address to)
         external payable returns (uint)
@@ -33,7 +33,7 @@ contract EthProxy {
     }
 
     /// @dev Users wishing to withdraw their Weth as ETH from USM should use this function.
-    /// Users must have called `controller.addDelegate(ethProxy.address)` to authorize EthProxy to act in their behalf.
+    /// Users must have called `controller.addDelegate(Proxy.address)` to authorize Proxy to act in their behalf.
     /// @param to Receiver of the obtained Eth
     /// @param usmToBurn Amount of USM to burn.
     function burn(address payable to, uint usmToBurn)

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -25,48 +25,103 @@ contract Proxy {
 
     /// @dev Users use `mint` in Proxy to post ETH to USM (amount = msg.value), which will be converted to Weth here.
     /// @param to Receiver of the minted USM
-    function mint(address to)
+    /// @param minUsmOut Minimum accepted USM for a successful mint.
+    function mintWithEth(address to, uint minUsmOut)
         external payable returns (uint)
     {
         weth.deposit{ value: msg.value }();
-        return usm.mint(address(this), to, msg.value);
+        uint usmOut = usm.mint(address(this), to, msg.value);
+        require(usmOut >= minUsmOut, "Limit not reached");
+        return usmOut;
+    }
+
+    /// @dev Users use `mint` in Proxy to post Weth to USM.
+    /// @param to Receiver of the minted USM
+    /// @param ethIn Amount of wrapped eth to use for minting USM.
+    /// @param minUsmOut Minimum accepted USM for a successful mint.
+    function mint(address to, uint ethIn, uint minUsmOut)
+        external returns (uint)
+    {
+        uint usmOut = usm.mint(msg.sender, to, ethIn);
+        require(usmOut >= minUsmOut, "Limit not reached");
+        return usmOut;
     }
 
     /// @dev Users wishing to withdraw their Weth as ETH from USM should use this function.
     /// Users must have called `controller.addDelegate(Proxy.address)` to authorize Proxy to act in their behalf.
-    /// @param to Receiver of the obtained Eth
+    /// @param to Receiver of the obtained ETH
     /// @param usmToBurn Amount of USM to burn.
-    function burn(address payable to, uint usmToBurn)
+    /// @param minEthOut Minimum accepted ETH for a successful burn.
+    function burnForEth(address payable to, uint usmToBurn, uint minEthOut)
         external returns (uint)
     {
-        uint wethToWithdraw = usm.burn(msg.sender, address(this), usmToBurn);
-        weth.withdraw(wethToWithdraw);
-        to.sendValue(wethToWithdraw);
-        return wethToWithdraw;
+        uint ethOut = usm.burn(msg.sender, address(this), usmToBurn);
+        require(ethOut >= minEthOut, "Limit not reached");
+        weth.withdraw(ethOut);
+        to.sendValue(ethOut);
+        return ethOut;
     }
 
-    /**
-     * @notice Funds the pool with ETH, converted to WETH
-     * @param to Receiver of the obtained FUM
-     */
-    function fund(address to)
+    /// @dev Users wishing to withdraw their Weth from USM should use this function.
+    /// Users must have called `controller.addDelegate(Proxy.address)` to authorize Proxy to act in their behalf.
+    /// @param to Receiver of the obtained wrapped ETH
+    /// @param usmToBurn Amount of USM to burn.
+    /// @param minEthOut Minimum accepted WETH for a successful burn.
+    function burn(address to, uint usmToBurn, uint minEthOut)
+        external returns (uint)
+    {
+        uint ethOut = usm.burn(msg.sender, to, usmToBurn);
+        require(ethOut >= minEthOut, "Limit not reached");
+        return ethOut;
+    }
+
+    /// @notice Funds the pool with ETH, converted to WETH
+    /// @param to Receiver of the obtained FUM
+    /// @param minFumOut Minimum accepted FUM for a successful burn.
+    function fundWithEth(address to, uint minFumOut)
         external payable returns (uint)
     {
         weth.deposit{ value: msg.value }();
-        return usm.fund(address(this), to, msg.value);
+        uint fumOut = usm.fund(address(this), to, msg.value);
+        require(fumOut >= minFumOut, "Limit not reached");
+        return fumOut;
     }
 
-    /**
-     * @notice Defunds the pool by sending FUM out in exchange for equivalent ETH from the pool
-     * @param to Receiver of the obtained ETH
-     * @param fumToBurn Amount of FUM to burn.
-     */
-    function defund(address payable to, uint fumToBurn)
+    /// @notice Funds the pool with WETH
+    /// @param to Receiver of the obtained FUM
+    /// @param ethIn Amount of wrapped eth to use for minting FUM.
+    /// @param minFumOut Minimum accepted FUM for a successful burn.
+    function fund(address to, uint ethIn, uint minFumOut)
         external returns (uint)
     {
-        uint wethToWithdraw = usm.defund(msg.sender, address(this), fumToBurn);
-        weth.withdraw(wethToWithdraw);
-        to.sendValue(wethToWithdraw);
-        return wethToWithdraw;
+        uint fumOut = usm.fund(msg.sender, to, ethIn); 
+        require(fumOut >= minFumOut, "Limit not reached");
+        return fumOut;
+    }
+
+    /// @notice Defunds the pool by sending FUM out in exchange for equivalent ETH from the pool
+    /// @param to Receiver of the obtained ETH
+    /// @param fumToBurn Amount of FUM to burn.
+    /// @param minEthOut Minimum accepted ETH for a successful defund.
+    function defundForEth(address payable to, uint fumToBurn, uint minEthOut)
+        external returns (uint)
+    {
+        uint ethOut = usm.defund(msg.sender, address(this), fumToBurn);
+        require(ethOut >= minEthOut, "Limit not reached");
+        weth.withdraw(ethOut);
+        to.sendValue(ethOut);
+        return ethOut;
+    }
+
+    /// @notice Defunds the pool by sending FUM out in exchange for equivalent WETH from the pool
+    /// @param to Receiver of the obtained ETH
+    /// @param fumToBurn Amount of FUM to burn.
+    /// @param minEthOut Minimum accepted WETH for a successful defund.
+    function defund(address to, uint fumToBurn, uint minEthOut)
+        external returns (uint)
+    {
+        uint ethOut = usm.defund(msg.sender, to, fumToBurn);
+        require(ethOut >= minEthOut, "Limit not reached");
+        return ethOut;
     }
 }

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -20,6 +20,10 @@ contract Proxy {
         weth.approve(address(usm), uint(-1));
     }
 
+    // -------------------
+    // Using Ether
+    // -------------------
+
     /// @dev The WETH9 contract will send ether to Proxy on `weth.withdraw` using this function.
     receive() external payable { }
 
@@ -31,18 +35,6 @@ contract Proxy {
     {
         weth.deposit{ value: msg.value }();
         uint usmOut = usm.mint(address(this), to, msg.value);
-        require(usmOut >= minUsmOut, "Limit not reached");
-        return usmOut;
-    }
-
-    /// @dev Users use `mint` in Proxy to post Weth to USM.
-    /// @param to Receiver of the minted USM
-    /// @param ethIn Amount of wrapped eth to use for minting USM.
-    /// @param minUsmOut Minimum accepted USM for a successful mint.
-    function mint(address to, uint ethIn, uint minUsmOut)
-        external returns (uint)
-    {
-        uint usmOut = usm.mint(msg.sender, to, ethIn);
         require(usmOut >= minUsmOut, "Limit not reached");
         return usmOut;
     }
@@ -62,19 +54,6 @@ contract Proxy {
         return ethOut;
     }
 
-    /// @dev Users wishing to withdraw their Weth from USM should use this function.
-    /// Users must have called `controller.addDelegate(Proxy.address)` to authorize Proxy to act in their behalf.
-    /// @param to Receiver of the obtained wrapped ETH
-    /// @param usmToBurn Amount of USM to burn.
-    /// @param minEthOut Minimum accepted WETH for a successful burn.
-    function burn(address to, uint usmToBurn, uint minEthOut)
-        external returns (uint)
-    {
-        uint ethOut = usm.burn(msg.sender, to, usmToBurn);
-        require(ethOut >= minEthOut, "Limit not reached");
-        return ethOut;
-    }
-
     /// @notice Funds the pool with ETH, converted to WETH
     /// @param to Receiver of the obtained FUM
     /// @param minFumOut Minimum accepted FUM for a successful burn.
@@ -83,18 +62,6 @@ contract Proxy {
     {
         weth.deposit{ value: msg.value }();
         uint fumOut = usm.fund(address(this), to, msg.value);
-        require(fumOut >= minFumOut, "Limit not reached");
-        return fumOut;
-    }
-
-    /// @notice Funds the pool with WETH
-    /// @param to Receiver of the obtained FUM
-    /// @param ethIn Amount of wrapped eth to use for minting FUM.
-    /// @param minFumOut Minimum accepted FUM for a successful burn.
-    function fund(address to, uint ethIn, uint minFumOut)
-        external returns (uint)
-    {
-        uint fumOut = usm.fund(msg.sender, to, ethIn); 
         require(fumOut >= minFumOut, "Limit not reached");
         return fumOut;
     }
@@ -111,6 +78,47 @@ contract Proxy {
         weth.withdraw(ethOut);
         to.sendValue(ethOut);
         return ethOut;
+    }
+
+    // -------------------
+    // Using Wrapped Ether
+    // -------------------
+
+    /// @dev Users use `mint` in Proxy to post Weth to USM.
+    /// @param to Receiver of the minted USM
+    /// @param ethIn Amount of wrapped eth to use for minting USM.
+    /// @param minUsmOut Minimum accepted USM for a successful mint.
+    function mint(address to, uint ethIn, uint minUsmOut)
+        external returns (uint)
+    {
+        uint usmOut = usm.mint(msg.sender, to, ethIn);
+        require(usmOut >= minUsmOut, "Limit not reached");
+        return usmOut;
+    }
+
+    /// @dev Users wishing to withdraw their Weth from USM should use this function.
+    /// Users must have called `controller.addDelegate(Proxy.address)` to authorize Proxy to act in their behalf.
+    /// @param to Receiver of the obtained wrapped ETH
+    /// @param usmToBurn Amount of USM to burn.
+    /// @param minEthOut Minimum accepted WETH for a successful burn.
+    function burn(address to, uint usmToBurn, uint minEthOut)
+        external returns (uint)
+    {
+        uint ethOut = usm.burn(msg.sender, to, usmToBurn);
+        require(ethOut >= minEthOut, "Limit not reached");
+        return ethOut;
+    }
+
+    /// @notice Funds the pool with WETH
+    /// @param to Receiver of the obtained FUM
+    /// @param ethIn Amount of wrapped eth to use for minting FUM.
+    /// @param minFumOut Minimum accepted FUM for a successful burn.
+    function fund(address to, uint ethIn, uint minFumOut)
+        external returns (uint)
+    {
+        uint fumOut = usm.fund(msg.sender, to, ethIn); 
+        require(fumOut >= minFumOut, "Limit not reached");
+        return fumOut;
     }
 
     /// @notice Defunds the pool by sending FUM out in exchange for equivalent WETH from the pool

--- a/test/04_Proxy_Eth.test.js
+++ b/test/04_Proxy_Eth.test.js
@@ -10,16 +10,16 @@ const Proxy = artifacts.require('./Proxy.sol')
 
 const burnSignature = id('burn(address,address,uint256)').slice(0, 10)
 const defundSignature = id('defund(address,address,uint256)').slice(0, 10)
-MAX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 
 require('chai').use(require('chai-as-promised')).should()
 
-contract('USM - Proxy', (accounts) => {
+contract('USM - Proxy - Eth', (accounts) => {
   let [deployer, user1, user2] = accounts
 
   const sides = { BUY: 0, SELL: 1 }
   const price = new BN('25000000000')
   const shift = new BN('8')
+  const MAX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
   const ZERO = new BN('0')
   const WAD = new BN('1000000000000000000')
   const oneEth = WAD
@@ -45,49 +45,79 @@ contract('USM - Proxy', (accounts) => {
 
       it('allows minting FUM', async () => {
 
-        await proxy.fund(user2, { from: user1, value: oneEth })
+        await proxy.fundWithEth(user2, 0, { from: user1, value: oneEth })
 
         const newEthPool = (await weth.balanceOf(usm.address))
         newEthPool.toString().should.equal(oneEth.toString())
       })
 
+      it('does not mint FUM if minimum not reached', async () => {
+        await expectRevert(
+          proxy.fundWithEth(user2, MAX, { from: user1, value: oneEth }),
+          "Limit not reached",
+        )
+      })
+
       describe('with existing FUM supply', () => {
         beforeEach(async () => {
-          await proxy.fund(user1, { from: user1, value: oneEth })
+          await proxy.fundWithEth(user1, 0, { from: user1, value: oneEth })
         })
 
         it('allows minting USM', async () => {
-          await proxy.mint(user2, { from: user1, value: oneEth })
+          await proxy.mintWithEth(user2, 0, { from: user1, value: oneEth })
           const usmBalance = (await usm.balanceOf(user2))
           usmBalance.toString().should.equal(oneEth.mul(priceWAD).div(WAD).toString())
         })
 
+        it('does not mint USM if minimum not reached', async () => {
+          await expectRevert(
+            proxy.mintWithEth(user2, MAX, { from: user1, value: oneEth }),
+            "Limit not reached",
+          )
+        })  
+
         describe('with existing USM supply', () => {
           beforeEach(async () => {
-            await proxy.mint(user1, { from: user1, value: oneEth })
+            await proxy.mintWithEth(user1, 0, { from: user1, value: oneEth })
           })
 
           it('allows burning FUM', async () => {
             const targetFumBalance = oneEth.mul(priceWAD).div(WAD) // see "allows minting FUM" above
             const startingBalance = await web3.eth.getBalance(user2)
 
-            await proxy.defund(user2, priceWAD.mul(new BN('3')).div(new BN('4')), { from: user1 }) // defund 75% of our fum
+            await proxy.defundForEth(user2, priceWAD.mul(new BN('3')).div(new BN('4')), 0, { from: user1 }) // defund 75% of our fum
             const newFumBalance = (await fum.balanceOf(user1))
             newFumBalance.toString().should.equal(targetFumBalance.div(new BN('4')).toString()) // should be 25% of what it was
 
             expect(await web3.eth.getBalance(user2)).bignumber.gt(startingBalance)
           })
 
+          it('does not burn FUM if minimum not reached', async () => {
+            await expectRevert(
+              proxy.burnForEth(user2, priceWAD.mul(new BN('3')).div(new BN('4')), MAX, { from: user1 }),
+              "Limit not reached",
+            )
+          })    
+
           it('allows burning USM', async () => {
             const usmBalance = (await usm.balanceOf(user1)).toString()
             const startingBalance = await web3.eth.getBalance(user2)
 
-            await proxy.burn(user2, usmBalance, { from: user1 })
+            await proxy.burnForEth(user2, usmBalance, 0, { from: user1 })
             const newUsmBalance = (await usm.balanceOf(user1))
             newUsmBalance.toString().should.equal('0')
 
             expect(await web3.eth.getBalance(user2)).bignumber.gt(startingBalance)
           })
+
+          it('does not burn USM if minimum not reached', async () => {
+            const usmBalance = (await usm.balanceOf(user1)).toString()
+
+            await expectRevert(
+              proxy.burnForEth(user2, usmBalance, MAX, { from: user1 }),
+              "Limit not reached",
+            )
+          })    
         })
       })
     })

--- a/test/04_USM_ethProxy.test.js
+++ b/test/04_USM_ethProxy.test.js
@@ -6,7 +6,7 @@ const TestOracle = artifacts.require('./TestOracle.sol')
 const WETH9 = artifacts.require('WETH9')
 const USM = artifacts.require('./USM.sol')
 const FUM = artifacts.require('./FUM.sol')
-const EthProxy = artifacts.require('./EthProxy.sol')
+const Proxy = artifacts.require('./Proxy.sol')
 
 const burnSignature = id('burn(address,address,uint256)').slice(0, 10)
 const defundSignature = id('defund(address,address,uint256)').slice(0, 10)
@@ -14,7 +14,7 @@ MAX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 
 require('chai').use(require('chai-as-promised')).should()
 
-contract('USM - EthProxy', (accounts) => {
+contract('USM - Proxy', (accounts) => {
   let [deployer, user1, user2] = accounts
 
   const sides = { BUY: 0, SELL: 1 }
@@ -35,7 +35,7 @@ contract('USM - EthProxy', (accounts) => {
       weth = await WETH9.new({ from: deployer })
       usm = await USM.new(oracle.address, weth.address, { from: deployer })
       fum = await FUM.at(await usm.fum())
-      proxy = await EthProxy.new(usm.address, weth.address, { from: deployer })
+      proxy = await Proxy.new(usm.address, weth.address, { from: deployer })
 
       await usm.addDelegate(proxy.address, burnSignature, MAX, { from: user1 })
       await usm.addDelegate(proxy.address, defundSignature, MAX, { from: user1 })

--- a/test/05_Proxy_Limits.test.js
+++ b/test/05_Proxy_Limits.test.js
@@ -1,0 +1,132 @@
+const { BN, expectRevert } = require('@openzeppelin/test-helpers')
+const { expect } = require('chai')
+const { id } = require('ethers/lib/utils')
+
+const TestOracle = artifacts.require('./TestOracle.sol')
+const WETH9 = artifacts.require('WETH9')
+const USM = artifacts.require('./USM.sol')
+const FUM = artifacts.require('./FUM.sol')
+const Proxy = artifacts.require('./Proxy.sol')
+
+const mintSignature = id('mint(address,address,uint256)').slice(0, 10)
+const burnSignature = id('burn(address,address,uint256)').slice(0, 10)
+const fundSignature = id('fund(address,address,uint256)').slice(0, 10)
+const defundSignature = id('defund(address,address,uint256)').slice(0, 10)
+
+require('chai').use(require('chai-as-promised')).should()
+
+contract('USM - Proxy - Limits', (accounts) => {
+  let [deployer, user1, user2] = accounts
+
+  const sides = { BUY: 0, SELL: 1 }
+  const price = new BN('25000000000')
+  const shift = new BN('8')
+  const MAX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+  const ZERO = new BN('0')
+  const WAD = new BN('1000000000000000000')
+  const oneEth = WAD
+  const oneUsm = WAD
+  const priceWAD = WAD.mul(price).div(new BN('10').pow(shift))
+
+  describe('mints and burns a static amount', () => {
+    let oracle, weth, usm, proxy
+
+    beforeEach(async () => {
+      // Deploy contracts
+      oracle = await TestOracle.new(price, shift, { from: deployer })
+      weth = await WETH9.new({ from: deployer })
+      usm = await USM.new(oracle.address, weth.address, { from: deployer })
+      fum = await FUM.at(await usm.fum())
+      proxy = await Proxy.new(usm.address, weth.address, { from: deployer })
+
+      await weth.deposit({ from: user1, value: oneEth.mul(new BN('2')) })
+      await weth.approve(usm.address, MAX, { from: user1 })
+
+      await usm.addDelegate(proxy.address, mintSignature, MAX, { from: user1 })
+      await usm.addDelegate(proxy.address, burnSignature, MAX, { from: user1 })
+      await usm.addDelegate(proxy.address, fundSignature, MAX, { from: user1 })
+      await usm.addDelegate(proxy.address, defundSignature, MAX, { from: user1 })
+    })
+
+    describe('minting and burning', () => {
+
+      it('allows minting FUM', async () => {
+
+        await proxy.fund(user2, oneEth, 0, { from: user1 })
+
+        const newEthPool = (await weth.balanceOf(usm.address))
+        newEthPool.toString().should.equal(oneEth.toString())
+      })
+
+      it('does not mint FUM if minimum not reached', async () => {
+        await expectRevert(
+          proxy.fund(user2, oneEth, MAX, { from: user1 }),
+          "Limit not reached",
+        )
+      })
+
+      describe('with existing FUM supply', () => {
+        beforeEach(async () => {
+          await proxy.fund(user1, oneEth, 0, { from: user1 })
+        })
+
+        it('allows minting USM', async () => {
+          await proxy.mint(user2, oneEth, 0, { from: user1 })
+          const usmBalance = (await usm.balanceOf(user2))
+          usmBalance.toString().should.equal(oneEth.mul(priceWAD).div(WAD).toString())
+        })
+
+        it('does not mint USM if minimum not reached', async () => {
+          await expectRevert(
+            proxy.mint(user2, oneEth, MAX, { from: user1 }),
+            "Limit not reached",
+          )
+        })  
+
+        describe('with existing USM supply', () => {
+          beforeEach(async () => {
+            await proxy.mint(user1, oneEth, 0, { from: user1 })
+          })
+
+          it('allows burning FUM', async () => {
+            const targetFumBalance = oneEth.mul(priceWAD).div(WAD) // see "allows minting FUM" above
+            const startingBalance = await weth.balanceOf(user2)
+
+            await proxy.defund(user2, priceWAD.mul(new BN('3')).div(new BN('4')), 0, { from: user1 }) // defund 75% of our fum
+            const newFumBalance = (await fum.balanceOf(user1))
+            newFumBalance.toString().should.equal(targetFumBalance.div(new BN('4')).toString()) // should be 25% of what it was
+
+            expect(await weth.balanceOf(user2)).bignumber.gt(startingBalance)
+          })
+
+          it('does not burn FUM if minimum not reached', async () => {
+            await expectRevert(
+              proxy.burn(user2, priceWAD.mul(new BN('3')).div(new BN('4')), MAX, { from: user1 }),
+              "Limit not reached",
+            )
+          })    
+
+          it('allows burning USM', async () => {
+            const usmBalance = (await usm.balanceOf(user1)).toString()
+            const startingBalance = await weth.balanceOf(user2)
+
+            await proxy.burn(user2, usmBalance, 0, { from: user1 })
+            const newUsmBalance = (await usm.balanceOf(user1))
+            newUsmBalance.toString().should.equal('0')
+
+            expect(await weth.balanceOf(user2)).bignumber.gt(startingBalance)
+          })
+
+          it('does not burn USM if minimum not reached', async () => {
+            const usmBalance = (await usm.balanceOf(user1)).toString()
+
+            await expectRevert(
+              proxy.burn(user2, usmBalance, MAX, { from: user1 }),
+              "Limit not reached",
+            )
+          })    
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Decided to extend the limit feature to Eth orders as well as Weth orders.

Since `Proxy` acts as an intermediary holder for the Eth / Weth conversions, the code has to be duplicated for Eth and for Weth (`burn` and `burnForEth` do different calls to `usm.burn`)

The renaming of `EthProxy` as `Proxy` messed up with the diff, sorry :(