### PR TITLE
Zero-Fee migration - Fixes #25

### DIFF
--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -84,8 +84,8 @@ contract USM is IUSM, ERC20Permit, Delegable, Ownable {
      */
     function migrate(address holder) external returns (uint, uint, uint) {
         require(
-            v2 != address(0),
-            "Migration contract not set"
+            msg.sender == v2,
+            "Only callable by migration contract"
         );
         require(
             migrationStart <= block.timestamp,
@@ -93,7 +93,7 @@ contract USM is IUSM, ERC20Permit, Delegable, Ownable {
         );
         require(
             delegates[holder][msg.sender][msg.sig] > block.timestamp,
-            "Only callable by migration contract"
+            "Holder didn't delegate"
         );
         
         uint usmAmount = this.balanceOf(holder);

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -82,7 +82,7 @@ contract USM is IUSM, ERC20Permit, Delegable, Ownable {
      * The holder must have given permission by calling usm.addDelegate(delegate, keccak256(migrate(address))))
      * @param holder Address of the holder to migrate
      */
-    function migrate(address holder) external returns (uint, uint, uint) {
+    function export(address holder) external returns (uint, uint, uint) {
         require(
             msg.sender == v2,
             "Only callable by migration contract"

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -26,10 +26,12 @@ contract USM is IUSM, ERC20Permit, Delegable, Ownable {
     uint public constant MIN_FUM_BUY_PRICE_HALF_LIFE = 24 * 60 * 60;    // 1 day
     uint public constant BUY_SELL_ADJUSTMENTS_HALF_LIFE = 60;           // 1 minute
 
-    address public v2;
     address public oracle;
     IERC20 public eth;
     FUM public fum;
+
+    address public v2;
+    uint public timelock;
 
     struct TimedValue {
         uint32 timestamp;
@@ -57,6 +59,7 @@ contract USM is IUSM, ERC20Permit, Delegable, Ownable {
      */
     function setV2(address v2_) public onlyOwner {
         v2 = v2_;
+        timelock = block.timestamp + (48 * 60 *60);
     }
 
     /**
@@ -66,6 +69,10 @@ contract USM is IUSM, ERC20Permit, Delegable, Ownable {
      * @param holder Address of the holder to migrate
      */
     function migrate(address holder) external returns (uint, uint, uint) {
+        require(
+            timelock <= block.timestamp,
+            "Only callable after the timelock"
+        );
         require(
             delegates[holder][msg.sender][msg.sig] > block.timestamp,
             "Only callable by migration contract"

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -78,8 +78,8 @@ contract USM is IUSM, ERC20Permit, Delegable, Ownable {
             "Only callable by migration contract"
         );
         
-        uint usmAmount = balanceOf(holder);
-        uint fumAmount = balanceOf(holder);
+        uint usmAmount = this.balanceOf(holder);
+        uint fumAmount = fum.balanceOf(holder);
 
         int buffer = ethBuffer();
         uint fumPrice = (buffer < 0 ? 0 : uint(buffer).wadDiv(fum.totalSupply()));

--- a/test/03_USM.test.js
+++ b/test/03_USM.test.js
@@ -215,7 +215,7 @@ contract('USM', (accounts) => {
           shouldEqual(fumSellPrice2, targetFumSellPrice2)
         })
 
-        describe.only("with existing USM supply", () => {
+        describe("with existing USM supply", () => {
           let ethPool, fumSellPrice, usmSellPrice
           let MAX_DEBT_RATIO, debtRatio0, price0
 


### PR DESCRIPTION
1. `owner` designates a v2 contract
2. `holders` give permission to the v2 contract to take their funds
3. The timelock passes
4. Anyone calls a function on the v2 contract that moves the funds of a `holder` from v1 to v2.

I think that allowing this feature should be carefully considered. We are introducing governance, even if limited.